### PR TITLE
fix: update action references to use correct owner and version

### DIFF
--- a/.github/DRAFT_README.md
+++ b/.github/DRAFT_README.md
@@ -1,9 +1,9 @@
 # Get Job Summary GitHub Action
 
-[![GitHub Super-Linter](https://github.com/yuki/get-job-summary/actions/workflows/linter.yml/badge.svg)](https://github.com/super-linter/super-linter)
-![CI](https://github.com/yuki/get-job-summary/actions/workflows/ci.yml/badge.svg)
-[![Check dist/](https://github.com/yuki/get-job-summary/actions/workflows/check-dist.yml/badge.svg)](https://github.com/yuki/get-job-summary/actions/workflows/check-dist.yml)
-[![CodeQL](https://github.com/yuki/get-job-summary/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/yuki/get-job-summary/actions/workflows/codeql-analysis.yml)
+[![GitHub Super-Linter](https://github.com/VeyronSakai/get-job-summary/actions/workflows/linter.yml/badge.svg)](https://github.com/super-linter/super-linter)
+![CI](https://github.com/VeyronSakai/get-job-summary/actions/workflows/ci.yml/badge.svg)
+[![Check dist/](https://github.com/VeyronSakai/get-job-summary/actions/workflows/check-dist.yml/badge.svg)](https://github.com/VeyronSakai/get-job-summary/actions/workflows/check-dist.yml)
+[![CodeQL](https://github.com/VeyronSakai/get-job-summary/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/VeyronSakai/get-job-summary/actions/workflows/codeql-analysis.yml)
 [![Coverage](./badges/coverage.svg)](./badges/coverage.svg)
 
 A TypeScript-based GitHub Action to retrieve job summary URLs and comprehensive
@@ -23,7 +23,7 @@ default workflow context.
 
 ```yaml
 - name: Get Job Summary
-  uses: yuki/get-job-summary@v1
+  uses: VeyronSakai/get-job-summary@v0.1
   id: job-info
   with:
     github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +81,7 @@ jobs:
         run: npm test
 
       - name: Get Job Summary
-        uses: yuki/get-job-summary@v1
+        uses: VeyronSakai/get-job-summary@v0.1
         id: job-info
 
       - name: Comment PR with Job Summary
@@ -100,7 +100,7 @@ jobs:
 
 ```yaml
 - name: Get Job Summary
-  uses: yuki/get-job-summary@v1
+  uses: VeyronSakai/get-job-summary@v0.1
   id: job-info
 
 - name: Notify Slack
@@ -126,7 +126,7 @@ jobs:
 ```yaml
 - name: Get Job Summary
   if: failure()
-  uses: yuki/get-job-summary@v1
+  uses: VeyronSakai/get-job-summary@v0.1
   id: job-info
 
 - name: Create Issue
@@ -146,7 +146,7 @@ jobs:
 
 ```yaml
 - name: Get Job Summary with Anchor
-  uses: yuki/get-job-summary@v1
+  uses: VeyronSakai/get-job-summary@v0.1
   id: job-info
   with:
     include_job_summary_anchor: true
@@ -176,7 +176,7 @@ jobs:
 
 ```bash
 # Clone the repository
-git clone https://github.com/yuki/get-job-summary.git
+git clone https://github.com/VeyronSakai/get-job-summary.git
 cd get-job-summary
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ including:
 
 ```yaml
 - name: Get Job Summary
-  uses: your-username/get-job-summary@v1
+  uses: VeyronSakai/get-job-summary@v0.1
   id: job-info
   with:
     github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +32,7 @@ including:
 
 ```yaml
 - name: Get Job Summary for Specific Job
-  uses: your-username/get-job-summary@v1
+  uses: VeyronSakai/get-job-summary@v0.1
   id: job-info
   with:
     repository: ${{ github.repository }}
@@ -45,7 +45,7 @@ including:
 
 ```yaml
 - name: Get Job Summary with Direct Link to Job
-  uses: your-username/get-job-summary@v1
+  uses: VeyronSakai/get-job-summary@v0.1
   id: job-info
   with:
     include_job_summary_anchor: true
@@ -104,7 +104,7 @@ jobs:
         run: npm test
 
       - name: Get Job Summary
-        uses: your-username/get-job-summary@v1
+        uses: VeyronSakai/get-job-summary@v0.1
         id: job-info
 
       - name: Comment PR with Job Summary
@@ -131,7 +131,7 @@ jobs:
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-username/get-job-summary.git
+git clone https://github.com/VeyronSakai/get-job-summary.git
 cd get-job-summary
 
 # Install dependencies


### PR DESCRIPTION
## Summary
- Update owner name from 'your-username' to 'VeyronSakai' in all action references
- Change version tag from 'v1' to 'v0.1' as v1 tag doesn't exist yet
- Update git clone URL in development section

## Changes
- Modified all GitHub Action usage examples in README.md
- Updated repository clone URL in development instructions

## Test plan
- [ ] Verify all action references now use `VeyronSakai/get-job-summary@v0.1`
- [ ] Ensure README examples are consistent and accurate
- [ ] Confirm CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)